### PR TITLE
レスポンスのデータ構造型を追加

### DIFF
--- a/GitHubSearchRepository/JSONDecodable.swift
+++ b/GitHubSearchRepository/JSONDecodable.swift
@@ -1,0 +1,11 @@
+//
+//  JSONDecodable.swift
+//  GitHubSearchRepository
+//
+//  Created by 伊藤静那(Ito Shizuna) on 2017/07/23.
+//  Copyright © 2017年 ShizunaIto. All rights reserved.
+//
+
+protocol JSONDecodable {
+    init(json: Any) throws
+}

--- a/GitHubSearchRepository/JSONDecodeError.swift
+++ b/GitHubSearchRepository/JSONDecodeError.swift
@@ -1,0 +1,12 @@
+//
+//  JSONDecodeError.swift
+//  GitHubSearchRepository
+//
+//  Created by 伊藤静那(Ito Shizuna) on 2017/07/23.
+//  Copyright © 2017年 ShizunaIto. All rights reserved.
+//
+
+enum JSONDecodeError : Error {
+    case invalidFormat(json: Any)
+    case missingValue(key: String, actualValue: Any?)
+}

--- a/GitHubSearchRepository/Repository.swift
+++ b/GitHubSearchRepository/Repository.swift
@@ -1,0 +1,42 @@
+//
+//  Repository.swift
+//  GitHubSearchRepository
+//
+//  Created by 伊藤静那(Ito Shizuna) on 2017/07/23.
+//  Copyright © 2017年 ShizunaIto. All rights reserved.
+//
+import Foundation
+
+struct Repository : JSONDecodable {
+    let id: Int
+    let name: String
+    let fullName: String
+    let owner: User
+    
+    init(json: Any) throws {
+        guard let dictionary = json as? [String : Any] else {
+            throw JSONDecodeError.invalidFormat(json: json)
+        }
+        
+        guard let id = dictionary["id"] as? Int else {
+            throw JSONDecodeError.missingValue(key: "id", actualValue: dictionary["id"])
+        }
+        
+        guard let name = dictionary["name"] as? String else {
+            throw JSONDecodeError.missingValue(key: "name", actualValue: dictionary["name"])
+        }
+        
+        guard let fullName = dictionary["full_name"] as? String else {
+            throw JSONDecodeError.missingValue(key: "full_name", actualValue: dictionary["full_name"])
+        }
+        
+        guard let ownerObject = dictionary["owner"] else {
+            throw JSONDecodeError.missingValue(key: "owner", actualValue: dictionary["owner"])
+        }
+        
+        self.id = id
+        self.name = name
+        self.fullName = fullName
+        self.owner = try User(json: ownerObject)
+    }
+}

--- a/GitHubSearchRepository/SearchResponse.swift
+++ b/GitHubSearchRepository/SearchResponse.swift
@@ -1,0 +1,36 @@
+//
+//  SearchResponse.swift
+//  GitHubSearchRepository
+//
+//  Created by 伊藤静那(Ito Shizuna) on 2017/07/23.
+//  Copyright © 2017年 ShizunaIto. All rights reserved.
+//
+
+import Foundation
+
+struct SearchResponse<Item : JSONDecodable> : JSONDecodable {
+    let totalCount: Int
+    let items: [Item]
+    
+    init(json: Any) throws {
+        guard let dictionary = json as? [String : Any] else {
+            throw JSONDecodeError.invalidFormat(json: json)
+        }
+        
+        guard let totalCount = dictionary["total_count"] as? Int else {
+            throw JSONDecodeError.missingValue(key: "total_count",
+                                               actualValue: dictionary["total_count"])
+        }
+        
+        guard let itemObjects = dictionary["items"] as? [Any] else {
+            throw JSONDecodeError.missingValue(key: "items", actualValue: dictionary["items"])
+        }
+        
+        let items = try itemObjects.map {
+            return try Item(json: $0)
+        }
+        
+        self.totalCount = totalCount
+        self.items = items
+    }
+}

--- a/GitHubSearchRepository/User.swift
+++ b/GitHubSearchRepository/User.swift
@@ -1,0 +1,30 @@
+//
+//  User.swift
+//  GitHubSearchRepository
+//
+//  Created by 伊藤静那(Ito Shizuna) on 2017/07/23.
+//  Copyright © 2017年 ShizunaIto. All rights reserved.
+//
+import Foundation
+
+struct User : JSONDecodable {
+    let id: Int
+    let login: String
+    
+    init(json: Any) throws {
+        guard let dictionary = json as? [String : Any] else {
+            throw JSONDecodeError.invalidFormat(json: json)
+        }
+        
+        guard let id = dictionary["id"] as? Int else {
+            throw JSONDecodeError.missingValue(key: "id", actualValue: dictionary["id"])
+        }
+        
+        guard let login = dictionary["login"] as? String else {
+            throw JSONDecodeError.missingValue(key: "login", actualValue: dictionary["login"])
+        }
+        
+        self.id = id
+        self.login = login
+    }
+}


### PR DESCRIPTION
## 内容
- User型の構造体を定義
- Repository型の構造体を定義
- JSONのdecode失敗時のエラーを定義
- JSONからインスタンスを生成するプロトコルを定義
- 検索結果全般を扱ジェネリックを定義
  - `totalCount`：返ってきた要素の総数
  - `items`：結果の要素